### PR TITLE
Suppress remaining Codacy/SonarCloud findings on legitimate uses

### DIFF
--- a/je_web_runner/utils/package_manager/package_manager_class.py
+++ b/je_web_runner/utils/package_manager/package_manager_class.py
@@ -6,7 +6,7 @@ from sys import stderr
 
 from je_web_runner.utils.logging.loggin_instance import web_runner_logger
 
-_VALID_MODULE_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$")
+_VALID_MODULE_NAME = re.compile(r"^[A-Za-z_]\w*(\.[A-Za-z_]\w*)*$", re.ASCII)
 
 
 class PackageManager(object):
@@ -37,7 +37,7 @@ class PackageManager(object):
             found_spec = find_spec(package)
             if found_spec is not None and _VALID_MODULE_NAME.match(found_spec.name):
                 try:
-                    installed_package = import_module(found_spec.name)
+                    installed_package = import_module(found_spec.name)  # nosemgrep: non-literal-import
                     self.installed_package_dict.update(
                         {found_spec.name: installed_package}
                     )

--- a/je_web_runner/utils/xml/xml_file/xml_file.py
+++ b/je_web_runner/utils/xml/xml_file/xml_file.py
@@ -1,6 +1,7 @@
 from defusedxml import ElementTree as DefusedElementTree
 from defusedxml.minidom import parseString as defused_parse_string
-from xml.etree import ElementTree
+# ElementTree class used only as a writer wrapper around an already-defused root.
+from xml.etree.ElementTree import ElementTree as _ETree  # nosec B405 # nosemgrep: use-defused-xml
 
 from je_web_runner.utils.exception.exception_tags import cant_read_xml_error
 from je_web_runner.utils.exception.exception_tags import xml_type_error
@@ -48,7 +49,7 @@ class XMLParser(object):
         else:
             self.xml_parser_from_file()
 
-    def xml_parser_from_string(self, **kwargs) -> ElementTree.Element:
+    def xml_parser_from_string(self, **kwargs):
         """
         從字串解析 XML
         Parse XML from string
@@ -62,7 +63,7 @@ class XMLParser(object):
             raise XMLException(cant_read_xml_error) from error
         return self.xml_root
 
-    def xml_parser_from_file(self, **kwargs) -> ElementTree.Element:
+    def xml_parser_from_file(self, **kwargs):
         """
         從檔案解析 XML
         Parse XML from file
@@ -88,5 +89,5 @@ class XMLParser(object):
         """
         write_content = write_content.strip()
         content = DefusedElementTree.fromstring(write_content)
-        tree = ElementTree.ElementTree(content)
+        tree = _ETree(content)
         tree.write(write_xml_filename, encoding="utf-8")

--- a/test/unit_test/test_xml_structure.py
+++ b/test/unit_test/test_xml_structure.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import Any, cast
 
 from defusedxml.ElementTree import fromstring
 
@@ -37,8 +38,9 @@ class TestXmlStructure(unittest.TestCase):
         self.assertEqual(result["root"]["value"], "123")
 
     def test_invalid_type_raises(self):
+        bad_input: Any = "not a dict"
         with self.assertRaises(TypeError):
-            dict_to_elements_tree("not a dict")
+            dict_to_elements_tree(cast(dict, bad_input))
 
     def test_multiple_root_keys_raises(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Summary
- Narrow `xml_file.py` import to `ElementTree as _ETree` (writer wrapper only) with `# nosec B405 # nosemgrep`; drop the broader module import that tripped Bandit B405 / Semgrep use-defused-xml
- Collapse module-name regex to `\w` with `re.ASCII` (Sonar S6353) and tag the gated `import_module` call `# nosemgrep`
- Wrap the intentionally-invalid argument in `cast(dict, ...)` so the type-mismatch negative test stops tripping Sonar S5655

## Test plan
- [x] `pytest test/unit_test/test_*.py` — 71 / 71 passing locally
- [ ] Codacy delta clean
- [ ] SonarCloud quality gate passes
- [ ] CI green