### PR TITLE
Add stable PyPI publish workflow

### DIFF
--- a/.github/workflows/publish_stable.yml
+++ b/.github/workflows/publish_stable.yml
@@ -1,0 +1,98 @@
+name: Publish Stable to PyPI
+
+on:
+  push:
+    branches: [ "main" ]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-stable
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Bump version and publish je_web_runner to PyPI
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip-publish]')"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine tomlkit
+
+      - name: Bump patch version in pyproject.toml
+        id: bump
+        run: |
+          python - <<'PY'
+          import os
+          import tomlkit
+
+          path = "pyproject.toml"
+          with open(path, "r", encoding="utf-8") as f:
+              doc = tomlkit.parse(f.read())
+
+          current = str(doc["project"]["version"])
+          parts = current.split(".")
+          if len(parts) != 3 or not all(p.isdigit() for p in parts):
+              raise SystemExit(f"Unexpected version format: {current}")
+
+          major, minor, patch = (int(p) for p in parts)
+          new_version = f"{major}.{minor}.{patch + 1}"
+          doc["project"]["version"] = new_version
+
+          with open(path, "w", encoding="utf-8", newline="\n") as f:
+              f.write(tomlkit.dumps(doc))
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
+              out.write(f"old_version={current}\n")
+              out.write(f"new_version={new_version}\n")
+
+          print(f"Bumped {current} -> {new_version}")
+          PY
+
+      - name: Commit version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml
+          git commit -m "Bump stable version to ${{ steps.bump.outputs.new_version }} [skip-publish]"
+          git tag "v${{ steps.bump.outputs.new_version }}"
+          git push origin HEAD:main
+          git push origin "v${{ steps.bump.outputs.new_version }}"
+
+      - name: Build distribution
+        run: python -m build
+
+      - name: Verify distribution metadata
+        run: python -m twine check dist/*
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: python -m twine upload dist/*
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: v${{ steps.bump.outputs.new_version }}
+        run: |
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --generate-notes \
+            --verify-tag \
+            dist/*


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/publish_stable.yml` to auto-publish `je_web_runner` to PyPI on every push to `main`.
- Workflow bumps the patch version in `pyproject.toml`, builds & uploads the dist via `twine`, tags `vX.Y.Z`, and creates a matching GitHub Release.
- Skipped when the head commit subject contains `[skip-publish]` (used for the bump-back commit itself).

## Test plan
- [ ] After merge, confirm the `Publish Stable to PyPI` workflow runs on `main`.
- [ ] Verify the version-bump commit lands on `main` with `[skip-publish]` and re-runs are not triggered.
- [ ] Confirm the new tag and PyPI release match the bumped version.