### PR TITLE
MCP server refresh + bug fixes since PR #87

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,11 +687,26 @@ WebRunner ships a [Model Context Protocol](https://modelcontextprotocol.io/) ser
 python -m je_web_runner.mcp_server
 ```
 
-The default tool list exposes:
+The default tool list (19 tools) exposes:
 
-- `webrunner_lint_action`, `webrunner_locator_strength`
-- `webrunner_render_template`, `webrunner_compute_trend`
-- `webrunner_validate_response`, `webrunner_summary_markdown`
+Action JSON authoring & linting:
+- `webrunner_lint_action`, `webrunner_score_action_locators`, `webrunner_locator_strength`
+- `webrunner_format_actions`, `webrunner_parse_markdown`, `webrunner_render_template`
+- `webrunner_translate_actions_to_playwright`, `webrunner_translate_python_to_playwright`
+
+Code generation:
+- `webrunner_pom_from_html`
+
+Quality / triage:
+- `webrunner_a11y_diff`, `webrunner_cluster_failures`, `webrunner_compute_trend`
+
+Security & privacy:
+- `webrunner_scan_pii`, `webrunner_redact_pii`
+
+Reporting & contract:
+- `webrunner_summary_markdown`, `webrunner_validate_response`
+
+Sharding & infra:
 - `webrunner_diff_shard`, `webrunner_render_k8s`, `webrunner_partition_shard`
 
 ```python

--- a/docs/source/Eng/doc/extended_features/extended_features_doc.rst
+++ b/docs/source/Eng/doc/extended_features/extended_features_doc.rst
@@ -380,11 +380,22 @@ drive it over JSON-RPC stdio:
 
    python -m je_web_runner.mcp_server
 
-Default tools registered: ``webrunner_lint_action``,
-``webrunner_locator_strength``, ``webrunner_render_template``,
-``webrunner_compute_trend``, ``webrunner_validate_response``,
-``webrunner_summary_markdown``, ``webrunner_diff_shard``,
-``webrunner_render_k8s``, ``webrunner_partition_shard``.
+Default tools registered (19 in total):
+
+* Action authoring & lint: ``webrunner_lint_action``,
+  ``webrunner_score_action_locators``, ``webrunner_locator_strength``,
+  ``webrunner_format_actions``, ``webrunner_parse_markdown``,
+  ``webrunner_render_template``,
+  ``webrunner_translate_actions_to_playwright``,
+  ``webrunner_translate_python_to_playwright``
+* Code generation: ``webrunner_pom_from_html``
+* Quality & triage: ``webrunner_a11y_diff``,
+  ``webrunner_cluster_failures``, ``webrunner_compute_trend``
+* Security: ``webrunner_scan_pii``, ``webrunner_redact_pii``
+* Reporting & contract: ``webrunner_summary_markdown``,
+  ``webrunner_validate_response``
+* Sharding / infra: ``webrunner_diff_shard``,
+  ``webrunner_render_k8s``, ``webrunner_partition_shard``
 
 Custom tools register via ``McpServer.register(Tool(...))``; the server
 implements MCP ``2024-11-05`` (``initialize`` / ``tools/list`` /

--- a/docs/source/Zh/doc/extended_features/extended_features_doc.rst
+++ b/docs/source/Zh/doc/extended_features/extended_features_doc.rst
@@ -264,12 +264,25 @@ MCP server
 
    python -m je_web_runner.mcp_server
 
-預設工具：``webrunner_lint_action`` / ``webrunner_locator_strength`` /
-``webrunner_render_template`` / ``webrunner_compute_trend`` /
-``webrunner_validate_response`` / ``webrunner_summary_markdown`` /
-``webrunner_diff_shard`` / ``webrunner_render_k8s`` /
-``webrunner_partition_shard``。可透過 ``McpServer.register(Tool(...))``
-擴充自訂工具，協定版本 ``2024-11-05``。
+預設工具共 19 個，依用途分組：
+
+* Action 撰寫 / lint：``webrunner_lint_action`` /
+  ``webrunner_score_action_locators`` / ``webrunner_locator_strength`` /
+  ``webrunner_format_actions`` / ``webrunner_parse_markdown`` /
+  ``webrunner_render_template`` /
+  ``webrunner_translate_actions_to_playwright`` /
+  ``webrunner_translate_python_to_playwright``
+* 程式碼生成：``webrunner_pom_from_html``
+* 品質 / triage：``webrunner_a11y_diff`` / ``webrunner_cluster_failures``
+  / ``webrunner_compute_trend``
+* 安全 / 隱私：``webrunner_scan_pii`` / ``webrunner_redact_pii``
+* 報告 / contract：``webrunner_summary_markdown`` /
+  ``webrunner_validate_response``
+* Sharding / infra：``webrunner_diff_shard`` / ``webrunner_render_k8s``
+  / ``webrunner_partition_shard``
+
+可透過 ``McpServer.register(Tool(...))`` 自行擴充工具，協定版本
+``2024-11-05``。
 
 Action JSON LSP
 ===============

--- a/je_web_runner/mcp_server/server.py
+++ b/je_web_runner/mcp_server/server.py
@@ -145,8 +145,10 @@ def _tool_lint_action(arguments: Dict[str, Any]) -> Any:
     actions = arguments.get("actions")
     if not isinstance(actions, list):
         raise McpServerError("'actions' must be a list")
-    return [{"index": f.index, "level": f.level, "message": f.message,
-             "rule": f.rule} for f in lint_action(actions)]
+    # ``lint_action`` returns ``List[Dict[str, Any]]`` with ``rule`` /
+    # ``severity`` / ``message`` / ``location`` keys; pass through verbatim
+    # so MCP clients see the same shape the Python API exposes.
+    return list(lint_action(actions))
 
 
 def _tool_locator_strength(arguments: Dict[str, Any]) -> Any:
@@ -230,6 +232,127 @@ def _tool_partition(arguments: Dict[str, Any]) -> Any:
         int(arguments.get("index", 1)),
         int(arguments.get("total", 1)),
     )
+
+
+def _tool_format_actions(arguments: Dict[str, Any]) -> Any:
+    from je_web_runner.utils.action_formatter.formatter import format_actions
+    actions = arguments.get("actions")
+    if not isinstance(actions, list):
+        raise McpServerError("'actions' must be a list")
+    return format_actions(actions, indent=int(arguments.get("indent", 2)))
+
+
+def _tool_parse_markdown(arguments: Dict[str, Any]) -> Any:
+    from je_web_runner.utils.md_authoring.markdown_to_actions import parse_markdown
+    text = arguments.get("text")
+    if not isinstance(text, str):
+        raise McpServerError("'text' must be a string")
+    return parse_markdown(text)
+
+
+def _tool_translate_actions_to_playwright(arguments: Dict[str, Any]) -> Any:
+    from je_web_runner.utils.sel_to_pw.translator import translate_action_list
+    actions = arguments.get("actions")
+    if not isinstance(actions, list):
+        raise McpServerError("'actions' must be a list")
+    return translate_action_list(actions)
+
+
+def _tool_translate_python_to_playwright(arguments: Dict[str, Any]) -> Any:
+    from je_web_runner.utils.sel_to_pw.translator import translate_python_source
+    source = arguments.get("source")
+    if not isinstance(source, str):
+        raise McpServerError("'source' must be a string")
+    translations = translate_python_source(source)
+    return [
+        {"line": t.line, "original": t.original,
+         "translated": t.translated, "note": t.note}
+        for t in translations
+    ]
+
+
+def _tool_pom_from_html(arguments: Dict[str, Any]) -> Any:
+    from je_web_runner.utils.pom_codegen.codegen import (
+        discover_elements_from_html,
+        render_pom_module,
+    )
+    html = arguments.get("html")
+    if not isinstance(html, str):
+        raise McpServerError("'html' must be a string")
+    elements = discover_elements_from_html(html)
+    class_name = str(arguments.get("class_name", "WebRunnerPage"))
+    return {
+        "module": render_pom_module(elements, class_name=class_name),
+        "elements": [
+            {"name": e.name, "strategy": e.strategy,
+             "value": e.value, "tag": e.tag, "source": e.source}
+            for e in elements
+        ],
+    }
+
+
+def _tool_scan_pii(arguments: Dict[str, Any]) -> Any:
+    from je_web_runner.utils.pii_scanner.scanner import scan_text
+    text = arguments.get("text")
+    if not isinstance(text, str):
+        raise McpServerError("'text' must be a string")
+    categories = arguments.get("categories")
+    findings = scan_text(text, categories=categories)
+    return [
+        {"category": f.category, "start": f.start,
+         "end": f.end, "redacted": f.redacted}
+        for f in findings
+    ]
+
+
+def _tool_redact_pii(arguments: Dict[str, Any]) -> Any:
+    from je_web_runner.utils.pii_scanner.scanner import redact_text
+    text = arguments.get("text")
+    if not isinstance(text, str):
+        raise McpServerError("'text' must be a string")
+    return redact_text(
+        text,
+        replacement=str(arguments.get("replacement", "[REDACTED]")),
+        categories=arguments.get("categories"),
+    )
+
+
+def _tool_cluster_failures(arguments: Dict[str, Any]) -> Any:
+    from je_web_runner.utils.failure_cluster.clustering import (
+        cluster_failures,
+        cluster_summary,
+    )
+    failures = arguments.get("failures")
+    if not isinstance(failures, list):
+        raise McpServerError("'failures' must be a list")
+    top_n = arguments.get("top_n")
+    if top_n is not None:
+        top_n = int(top_n)
+    clusters = cluster_failures(failures, top_n=top_n)
+    return cluster_summary(clusters)
+
+
+def _tool_a11y_diff(arguments: Dict[str, Any]) -> Any:
+    from je_web_runner.utils.accessibility.a11y_diff import diff_violations
+    baseline = arguments.get("baseline")
+    current = arguments.get("current")
+    if not isinstance(baseline, list) or not isinstance(current, list):
+        raise McpServerError("'baseline' and 'current' must be lists")
+    diff = diff_violations(baseline, current)
+    return {
+        "added": diff.added,
+        "resolved": diff.resolved,
+        "persisting": diff.persisting,
+        "regressed": diff.regressed,
+    }
+
+
+def _tool_score_action_locators(arguments: Dict[str, Any]) -> Any:
+    from je_web_runner.utils.linter.locator_strength import score_action_locators
+    actions = arguments.get("actions")
+    if not isinstance(actions, list):
+        raise McpServerError("'actions' must be a list")
+    return list(score_action_locators(actions))
 
 
 def build_default_tools() -> List[Tool]:
@@ -350,6 +473,146 @@ def build_default_tools() -> List[Tool]:
                 "required": ["paths", "index", "total"],
             },
             handler=_tool_partition,
+        ),
+        Tool(
+            name="webrunner_format_actions",
+            description="Format an action JSON list with canonical kwarg order.",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "actions": {"type": "array"},
+                    "indent": {"type": "integer"},
+                },
+                "required": ["actions"],
+            },
+            handler=_tool_format_actions,
+        ),
+        Tool(
+            name="webrunner_parse_markdown",
+            description="Transpile a Markdown bullet list into a WR_* action list.",
+            input_schema={
+                "type": "object",
+                "properties": {"text": {"type": "string"}},
+                "required": ["text"],
+            },
+            handler=_tool_parse_markdown,
+        ),
+        Tool(
+            name="webrunner_translate_actions_to_playwright",
+            description=(
+                "Rewrite a WR_* action list to its WR_pw_* Playwright"
+                " equivalent (drops WR_implicitly_wait)."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {"actions": {"type": "array"}},
+                "required": ["actions"],
+            },
+            handler=_tool_translate_actions_to_playwright,
+        ),
+        Tool(
+            name="webrunner_translate_python_to_playwright",
+            description=(
+                "Static translator: rewrites Selenium-style Python source"
+                " into Playwright equivalents; returns per-line diffs."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {"source": {"type": "string"}},
+                "required": ["source"],
+            },
+            handler=_tool_translate_python_to_playwright,
+        ),
+        Tool(
+            name="webrunner_pom_from_html",
+            description=(
+                "Discover [data-testid] / id / form fields in HTML and"
+                " render a Python Page Object module."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "html": {"type": "string"},
+                    "class_name": {"type": "string"},
+                },
+                "required": ["html"],
+            },
+            handler=_tool_pom_from_html,
+        ),
+        Tool(
+            name="webrunner_scan_pii",
+            description=(
+                "Scan text for PII (email / phone / Luhn-card / SSN /"
+                " ROC ID / IPv4); returns category + redacted preview."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "text": {"type": "string"},
+                    "categories": {"type": "array", "items": {"type": "string"}},
+                },
+                "required": ["text"],
+            },
+            handler=_tool_scan_pii,
+        ),
+        Tool(
+            name="webrunner_redact_pii",
+            description="Replace each detected PII match with a sentinel string.",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "text": {"type": "string"},
+                    "replacement": {"type": "string"},
+                    "categories": {"type": "array", "items": {"type": "string"}},
+                },
+                "required": ["text"],
+            },
+            handler=_tool_redact_pii,
+        ),
+        Tool(
+            name="webrunner_cluster_failures",
+            description=(
+                "Group failures by normalised error signature; returns"
+                " top buckets sorted by count."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "failures": {"type": "array"},
+                    "top_n": {"type": "integer"},
+                },
+                "required": ["failures"],
+            },
+            handler=_tool_cluster_failures,
+        ),
+        Tool(
+            name="webrunner_a11y_diff",
+            description=(
+                "Diff two axe-core ``violations`` arrays and bucket the"
+                " findings into added / resolved / persisting."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "baseline": {"type": "array"},
+                    "current": {"type": "array"},
+                },
+                "required": ["baseline", "current"],
+            },
+            handler=_tool_a11y_diff,
+        ),
+        Tool(
+            name="webrunner_score_action_locators",
+            description=(
+                "Score every locator referenced by an action JSON list on"
+                " a 0–100 scale; lower = more fragile."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {"actions": {"type": "array"}},
+                "required": ["actions"],
+            },
+            handler=_tool_score_action_locators,
         ),
     ]
 

--- a/test/unit_test/test_mcp_server.py
+++ b/test/unit_test/test_mcp_server.py
@@ -118,6 +118,121 @@ class TestDefaultTools(unittest.TestCase):
         for tool in build_default_tools():
             self.assertEqual(tool.input_schema["type"], "object")
 
+    def test_full_default_tool_surface(self):
+        # The MCP server is the public LLM-facing surface; freeze the tool
+        # list here so accidental removals fail loudly in review.
+        names = {tool.name for tool in build_default_tools()}
+        self.assertEqual(names, {
+            "webrunner_lint_action",
+            "webrunner_locator_strength",
+            "webrunner_render_template",
+            "webrunner_compute_trend",
+            "webrunner_validate_response",
+            "webrunner_summary_markdown",
+            "webrunner_diff_shard",
+            "webrunner_render_k8s",
+            "webrunner_partition_shard",
+            "webrunner_format_actions",
+            "webrunner_parse_markdown",
+            "webrunner_translate_actions_to_playwright",
+            "webrunner_translate_python_to_playwright",
+            "webrunner_pom_from_html",
+            "webrunner_scan_pii",
+            "webrunner_redact_pii",
+            "webrunner_cluster_failures",
+            "webrunner_a11y_diff",
+            "webrunner_score_action_locators",
+        })
+
+
+class TestNewTools(unittest.TestCase):
+
+    def setUp(self):
+        self.server = make_default_server()
+
+    def _call(self, name, arguments):
+        return self.server.handle({"id": 1, "method": "tools/call", "params": {
+            "name": name, "arguments": arguments,
+        }})
+
+    def test_format_actions(self):
+        result = self._call("webrunner_format_actions",
+                            {"actions": [["WR_quit_all"]]})
+        self.assertFalse(result["result"]["isError"])
+        self.assertIn('["WR_quit_all"]', result["result"]["content"][0]["text"])
+
+    def test_parse_markdown(self):
+        result = self._call("webrunner_parse_markdown",
+                            {"text": "- open https://example.com\n- quit"})
+        body = result["result"]["content"][0]["text"]
+        self.assertIn("WR_to_url", body)
+        self.assertIn("WR_quit_all", body)
+
+    def test_translate_actions_to_playwright(self):
+        result = self._call("webrunner_translate_actions_to_playwright", {
+            "actions": [["WR_to_url", {"url": "https://x"}]],
+        })
+        self.assertIn("WR_pw_to_url", result["result"]["content"][0]["text"])
+
+    def test_translate_python_to_playwright(self):
+        result = self._call("webrunner_translate_python_to_playwright", {
+            "source": "driver.get('https://x.com')",
+        })
+        self.assertIn("page.goto", result["result"]["content"][0]["text"])
+
+    def test_pom_from_html(self):
+        html = '<button data-testid="primary-cta">Go</button>'
+        result = self._call("webrunner_pom_from_html",
+                            {"html": html, "class_name": "Login"})
+        body = result["result"]["content"][0]["text"]
+        self.assertIn("class Login", body)
+        self.assertIn("primary_cta", body)
+
+    def test_scan_pii(self):
+        result = self._call("webrunner_scan_pii",
+                            {"text": "email alice@example.com here"})
+        body = result["result"]["content"][0]["text"]
+        self.assertIn("email", body)
+
+    def test_redact_pii(self):
+        result = self._call("webrunner_redact_pii", {
+            "text": "email alice@example.com here",
+            "replacement": "[X]",
+        })
+        self.assertIn("[X]", result["result"]["content"][0]["text"])
+
+    def test_cluster_failures(self):
+        result = self._call("webrunner_cluster_failures", {
+            "failures": [
+                {"function_name": "a", "exception": "TimeoutError at 0xab"},
+                {"function_name": "b", "exception": "TimeoutError at 0xcd"},
+            ]
+        })
+        body = result["result"]["content"][0]["text"]
+        self.assertIn('"count": 2', body)
+
+    def test_a11y_diff(self):
+        result = self._call("webrunner_a11y_diff", {
+            "baseline": [],
+            "current": [{
+                "id": "label",
+                "impact": "serious",
+                "nodes": [{"target": ["input.email"]}],
+            }],
+        })
+        body = result["result"]["content"][0]["text"]
+        self.assertIn('"regressed": true', body)
+
+    def test_score_action_locators(self):
+        result = self._call("webrunner_score_action_locators", {
+            "actions": [
+                ["WR_save_test_object",
+                 {"test_object_name": "submit", "object_type": "ID"}],
+            ],
+        })
+        body = result["result"]["content"][0]["text"]
+        self.assertIn("score", body)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

52 commits since PR #87 merged. The big-ticket item is bringing the MCP server up to date and the bugs that audit caught.

### MCP server: 9 → 19 tools

The MCP server was last updated when only nine helpers existed. Around 30 new pure-function modules have landed since (action_formatter, md_authoring, sel_to_pw, pom_codegen, pii_scanner, failure_cluster, accessibility.a11y_diff, locator_strength's batch scorer, …). This PR wires the most useful 10 of them into ``build_default_tools()``:

| Category | New tools |
|---|---|
| Action authoring | `webrunner_format_actions`, `webrunner_parse_markdown`, `webrunner_translate_actions_to_playwright`, `webrunner_translate_python_to_playwright`, `webrunner_score_action_locators` |
| Code generation | `webrunner_pom_from_html` |
| Quality / triage | `webrunner_a11y_diff`, `webrunner_cluster_failures` |
| Security / privacy | `webrunner_scan_pii`, `webrunner_redact_pii` |

### Bug found by the MCP audit

`_tool_lint_action` used dataclass-style attribute access (`f.level`, `f.message`, `f.rule`) but `lint_action` actually returns `List[Dict[str, Any]]`. **Every MCP `tools/call` against `webrunner_lint_action` was crashing** with `'dict' object has no attribute 'level'`. Now passes the list through verbatim, matching the Python API's shape.

### Surface-freeze test

`TestDefaultTools.test_full_default_tool_surface` asserts the 19-tool set explicitly so accidental removals fail loudly in review.

### Earlier rounds rolled into this PR

- WR_sleep executor command + the `examples/` cookbook (counting_stars, google_search, form_submit, smart_wait_demo, fanout_demo, pii_redact_demo, quick_smoke).
- Comprehensive integration test suite under `test/integration_test/` — 30 tests across 10 files wiring 2+ modules with real I/O. Surfaced a Windows-only LSP CRLF framing bug in `python -m je_web_runner.action_lsp` (fixed by `sys.stdout.reconfigure(newline="")`).
- Real-browser E2E scaffold under `test/e2e_test/` plus `.github/workflows/e2e_browser.yml` running daily against `selenium/hub:4.20.0`.
- Thematic façade `je_web_runner.api.{authoring, debugging, frontend, infra, mobile, networking, observability, quality, reliability, security, test_data}` re-exporting the 80+ helpers.
- Sphinx autodoc + autosummary; new `api_reference.rst` with mock imports for soft deps.
- Static-analysis cleanup (4 rounds against PR #86's review): ~30 Codacy + 30+ SonarCloud items resolved across cog-complexity refactors, suppression-syntax fixes (S7632), reflected-input hardening (S5131 + `_safe_echo`), nested-ternary collapse (S3358), and security annotations (S5042 / S4828 / S5332 / S5852 / S1313).
- Optimisation pass: 7 pytest collection warnings cleared; `workspace_lock` distribution walk cached; `socket_server` quit tests went from 2.42s → 0.49s; suite −25%.

### Bug catalogue across this PR

1. `webdriver_wrapper.execute_script` swallowed return values — caught by JSON cookbook smoke. Fixed.
2. LSP `Content-Length` framing corrupted on Windows by stdout newline translation — caught by integration subprocess test. Fixed via `sys.stdout.reconfigure(newline="")`.
3. Subprocess tests' `_fileobj2output` AttributeError + `I/O operation on closed file` — caught in CI rerun. Fixed by switching to `proc.communicate(input=...)` instead of manual `stdin.close()`.
4. `_tool_lint_action` dict-vs-dataclass shape mismatch — caught while auditing for this PR. Fixed.

### Numbers
- Tests: 1184 → **1241** (1200 unit + 41 integration / MCP).
- 0 collection warnings.
- Combined unit + integration suite ~17s.

## Test plan
- [ ] Unit + integration green on Python 3.10 / 3.11 / 3.12 / 3.13.
- [ ] Daily E2E workflow runs against Selenium Grid.
- [ ] Sphinx autosummary builds on the new sections.
- [ ] PyPI publish workflow fires on merge.