### PR TITLE
Merge dev into main: Python 3.14 CI, MCP expansion, demos & cookbook

### DIFF
--- a/.github/workflows/test_dev.yml
+++ b/.github/workflows/test_dev.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     env:
       # webdriver-manager calls api.github.com to find geckodriver/chromedriver

--- a/.github/workflows/test_stable.yml
+++ b/.github/workflows/test_stable.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     env:
       # webdriver-manager hits api.github.com for geckodriver/chromedriver


### PR DESCRIPTION
## Summary
- Add Python 3.14 to the CI test matrix in both `test_dev.yml` and `test_stable.yml` (alongside 3.10–3.13).
- Roll up the dev branch into main: MCP server expansion (9 → 19 tools, plus browser-execution tools), `WR_sleep`, thematic API façade, action-JSON cookbook, real-browser E2E scaffold, Sphinx autodoc, demos (Rescue Me autoplay, Counting Stars), and the static-analysis fixes from PR #86.

## Test plan
- [ ] CI green on Ubuntu unit tests for Python 3.10 / 3.11 / 3.12 / 3.13 / 3.14
- [ ] CI green on Windows integration tests for the same matrix
- [ ] No regressions in nightly E2E browser smoke