### PR TITLE
Fix Sphinx docs build warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,8 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/build/
+docs/source/Eng/doc/api_reference/generated/
 
 # PyBuilder
 target/

--- a/docs/source/Eng/doc/extended_features/extended_features_doc.rst
+++ b/docs/source/Eng/doc/extended_features/extended_features_doc.rst
@@ -280,8 +280,8 @@ Reliability helpers
 * ``throttler.throttle("payments-api")`` — file-semaphore for cross-shard
   concurrency limits.
 
-Observability
-=============
+Observability tooling
+=====================
 
 * ``observability.timeline.build(spans=, console=, responses=)`` —
   merges three event sources into a chronological list.

--- a/docs/source/Zh/doc/extended_features/extended_features_doc.rst
+++ b/docs/source/Zh/doc/extended_features/extended_features_doc.rst
@@ -94,7 +94,7 @@ Appium（行動）
 * HTML — 單一 ``<base>.html``
 * JSON — 拆分 ``<base>_success.json`` + ``<base>_failure.json``
 * XML — 拆分 ``<base>_success.xml`` + ``<base>_failure.xml``
-* JUnit XML — 單一 ``<base>_junit.xml``（CI 原生）
+* JUnit XML — 單一 ``<base>_junit.xml``\ （CI 原生）
 * Allure — 目錄含多個 ``<uuid>-result.json``
 
 ``generate_all_reports(base, allure_dir=None)`` 一次跑完所有 generator 並

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,6 +28,10 @@ extensions = [
 
 # Autosummary writes per-module reference pages on every build.
 autosummary_generate = True
+# autosectionlabel collides on common section titles (Overview, Methods,
+# Parameters, plus repeated CJK headings). Prefix every label with the
+# document path so duplicates become unique.
+autosectionlabel_prefix_document = True
 autodoc_default_options = {
     "members": True,
     "undoc-members": False,

--- a/je_web_runner/element/web_element_wrapper.py
+++ b/je_web_runner/element/web_element_wrapper.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List, Union
 
 from selenium.webdriver.remote.webelement import WebElement

--- a/je_web_runner/utils/smart_wait/smart_wait.py
+++ b/je_web_runner/utils/smart_wait/smart_wait.py
@@ -128,7 +128,7 @@ def wait_for_spa_route_stable(
 ) -> None:
     """
     等到 ``history.pushState`` / ``replaceState`` / ``popstate``
-    Wait until no history mutation has fired for at least ``quiet_for``s.
+    Wait until no history mutation has fired for at least ``quiet_for``\\ s.
     """
     install_hooks(driver)
     deadline = time.monotonic() + timeout

--- a/je_web_runner/webdriver/webdriver_with_options.py
+++ b/je_web_runner/webdriver/webdriver_with_options.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Union, List, Set
 
 from selenium import webdriver

--- a/je_web_runner/webdriver/webdriver_wrapper.py
+++ b/je_web_runner/webdriver/webdriver_wrapper.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing
 from pathlib import Path
 from typing import List, Union


### PR DESCRIPTION
## Summary
- Set ``autosectionlabel_prefix_document = True`` so common section titles (Overview / Methods / Parameters / 概述) stop colliding across files — clears ~70 duplicate-label warnings.
- Fix ``smart_wait.wait_for_spa_route_stable`` docstring: ``\`\`quiet_for\`\`s`` violated docutils' inline-literal close rule; escaped to ``\`\`quiet_for\`\`\ s``.
- Fix Zh ``extended_features_doc.rst:97``: closing inline literal was directly followed by full-width ``（`` — added ``\ `` separator.
- Rename the second ``Observability`` heading in Eng ``extended_features_doc.rst`` to ``Observability tooling`` so two sections in the same file don't collide.
- Add ``docs/build/`` and the autosummary ``generated/`` tree to ``.gitignore``.

After these changes ``sphinx-build -W --keep-going`` succeeds with zero warnings, so RTD builds (and any future ``-W`` CI gate) won't fail.

## Test plan
- [ ] RTD build green on this branch
- [ ] ``cd docs && python -m sphinx -b html -W --keep-going source build/html`` succeeds locally