### PR TITLE
Fix RTD build: mock remaining runtime dependencies

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,6 +50,10 @@ autodoc_mock_imports = [
     "opentelemetry",
     "axe_selenium_python",
     "testcontainers",
+    "webdriver_manager",
+    "requests",
+    "dotenv",
+    "defusedxml",
 ]
 
 # sphinxcontrib-mermaid renders the ``.. mermaid::`` directive used in


### PR DESCRIPTION
## Summary
RTD only installs ``docs/requirements.txt`` (sphinx + theme + mermaid), so any
top-level project dependency not listed in ``autodoc_mock_imports`` aborts the
autosummary import sweep with ``ModuleNotFoundError``. Reproduced in a clean
local venv that mirrors RTD's setup (no selenium / webdriver_manager / requests
/ dotenv / defusedxml installed).

Added the missing four mocks to ``docs/source/conf.py``:

- ``webdriver_manager`` (the actual culprit reported in the latest RTD log)
- ``requests``
- ``dotenv``
- ``defusedxml``

After the change ``sphinx-build -W --keep-going`` succeeds in the selenium-less
venv with zero warnings.

## Test plan
- [ ] RTD build green (latest + stable)
- [ ] ``cd docs && python -m sphinx -b html -W --keep-going source build/html`` clean in a venv that lacks the project deps