### PR TITLE
Install pytest in e2e_browser workflow

### DIFF
--- a/.github/workflows/e2e_browser.yml
+++ b/.github/workflows/e2e_browser.yml
@@ -46,6 +46,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel
           pip install -r dev_requirements.txt
+          pip install pytest
 
       - name: Wait for Grid to be ready
         run: |


### PR DESCRIPTION
## Summary
The E2E browser workflow installs ``dev_requirements.txt`` but neither
that file nor ``requirements.txt`` lists pytest, so ``python -m pytest
test/e2e_test/ -m e2e -v`` aborted with ``No module named pytest`` on
the GitHub-hosted runner. Add an explicit ``pip install pytest`` step,
matching the pattern already used in ``test_dev.yml`` /
``test_stable.yml``.

## Test plan
- [ ] Trigger ``E2E Browser Smoke`` via workflow_dispatch and confirm
      pytest resolves
- [ ] Next scheduled (06:00 UTC) run is green