### PR TITLE
Require Pillow 12.3.0 or newer at install time

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -5,7 +5,7 @@ je_web_runner_dev
 sphinx-rtd-theme
 Pyside6
 defusedxml
-Pillow
+Pillow>=12.3.0
 faker
 sqlalchemy
 pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,9 @@ dependencies = [
     'python-dotenv',
     "webdriver-manager",
     "defusedxml",
-    "Pillow",
+    # Floor set to the first release without the known Pillow advisories;
+    # wheels cover cp310-cp315, so it excludes no supported interpreter.
+    "Pillow>=12.3.0",
 ]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 je_web_runner
 defusedxml
-Pillow
+Pillow>=12.3.0
 faker
 sqlalchemy


### PR DESCRIPTION
Follow-up to the Pillow bump in #103.

That PR raised `uv.lock` to 12.3.0, which cleared the Dependabot alerts, but
the lockfile only constrains the uv environment. `pyproject.toml` declared
`Pillow` with no bound, so anyone installing the published package resolved
whatever version PyPI happened to serve — including vulnerable ones, if a
constraint elsewhere in their environment held Pillow back.

This adds the floor where it actually binds installers:

| File | Before | After |
|---|---|---|
| `pyproject.toml` | `Pillow` | `Pillow>=12.3.0` |
| `requirements.txt` | `Pillow` | `Pillow>=12.3.0` |
| `dev_requirements.txt` | `Pillow` | `Pillow>=12.3.0` |

`dev.toml` is deliberately untouched — `je_web_runner_dev` does not declare
Pillow at all, because the imaging paths (`visual_ai`, `ocr_assert`,
`visual_regression`) import PIL lazily. Adding it there would be a new
dependency, not a bound.

## Compatibility

12.3.0 publishes wheels for cp310 through cp315, so the floor excludes no
interpreter covered by `requires-python = ">=3.10"`.

## Verification

Built the wheel and confirmed the constraint reaches the published metadata,
which is what installers actually read:

```
Requires-Python: >=3.10
Requires-Dist: selenium>=4.0.0
Requires-Dist: requests
Requires-Dist: python-dotenv
Requires-Dist: webdriver-manager
Requires-Dist: defusedxml
Requires-Dist: Pillow>=12.3.0
```

`twine check` PASSED. Test suite: 4375 passed, 9 skipped, 22 subtests passed.

Note this one should publish normally — unlike the dependency PRs, it changes
the package's install contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)