### PR TITLE
Add lower bounds to the remaining runtime dependencies

### DIFF
--- a/dev.toml
+++ b/dev.toml
@@ -13,12 +13,13 @@ authors = [
 description = "WEB Automation Framework"
 requires-python = ">=3.10"
 license-files = ["LICENSE"]
+# Kept in step with pyproject.toml; see the rationale for each floor there.
 dependencies = [
     "selenium>=4.0.0",
-    "requests",
-    "python-dotenv",
-    "webdriver-manager",
-    "defusedxml",
+    "requests>=2.33.0",
+    "python-dotenv>=1.0.0",
+    "webdriver-manager>=4.0.0",
+    "defusedxml>=0.7.1",
 ]
 classifiers = [
     "Programming Language :: Python :: 3.10",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -4,7 +4,7 @@ sphinx
 je_web_runner_dev
 sphinx-rtd-theme
 Pyside6
-defusedxml
+defusedxml>=0.7.1
 Pillow>=12.3.0
 faker
 sqlalchemy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,19 @@ keywords = [
     "selenium", "automation", "testing", "web-automation",
     "webdriver", "browser", "e2e", "qa",
 ]
+# Every runtime dependency carries a lower bound so an installer cannot
+# silently resolve a version predating a known advisory or an API this
+# package relies on. Floors are minimums, not pins — upper bounds are left
+# open so the package stays co-installable.
 dependencies = [
     "selenium>=4.0.0",
-    'requests',
-    'python-dotenv',
-    "webdriver-manager",
-    "defusedxml",
+    # 2.33.0 is the first release carrying the extract_zipped_paths fix
+    # (GHSA-gc5v-m9x4-r6x2).
+    "requests>=2.33.0",
+    "python-dotenv>=1.0.0",
+    # 4.x is the line this package is developed and tested against.
+    "webdriver-manager>=4.0.0",
+    "defusedxml>=0.7.1",
     # Floor set to the first release without the known Pillow advisories;
     # wheels cover cp310-cp315, so it excludes no supported interpreter.
     "Pillow>=12.3.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 je_web_runner
-defusedxml
+defusedxml>=0.7.1
 Pillow>=12.3.0
 faker
 sqlalchemy


### PR DESCRIPTION
Follow-up to #105, which floored Pillow. The other runtime dependencies were
still declared unbounded, so an installer could resolve any version —
including ones predating known advisories — whenever another constraint in
the environment held them back.

| Dependency | Before | After |
|---|---|---|
| `requests` | unbounded | `>=2.33.0` |
| `python-dotenv` | unbounded | `>=1.0.0` |
| `webdriver-manager` | unbounded | `>=4.0.0` |
| `defusedxml` | unbounded | `>=0.7.1` |

Applied to `pyproject.toml`, `dev.toml` (both published packages) and the
`defusedxml` entries in `requirements.txt` / `dev_requirements.txt`.

## Why these floors

- **requests 2.33.0** is the first release carrying the `extract_zipped_paths`
  fix (GHSA-gc5v-m9x4-r6x2, published March 2026). This is the one floor with
  a concrete security driver.
- **webdriver-manager 4.0.0** is the line this package is developed and tested
  against. Worth being explicit: this is a *policy* floor, not an API
  requirement — 3.9.1 does expose both `DriverCacheManager` and the
  `cache_manager` kwarg that `webdriver_wrapper` passes, so the code would run
  on it. 4.x is simply what is exercised.
- **python-dotenv 1.0.0** and **defusedxml 0.7.1** are the current stable
  lines (defusedxml 0.7.1 has been latest since 2021).

All are minimums with no upper bounds, so the package stays co-installable.
The trade-off worth noting is `requests>=2.33.0`: it is a recent release, so
it will force an upgrade in environments pinning older requests. That is the
intent of a security floor, but it is the most likely of these to be felt.

## Deliberately not bounded

`faker` and `sqlalchemy` are optional extras, imported lazily behind guards
(`_require_faker()`, function-local `from sqlalchemy import ...`) and absent
from the package metadata entirely. A floor there would add friction without
a security benefit.

## Verification

Local venv was still on the vulnerable Pillow 12.2.0, below the floor #105
published. Upgraded it and re-ran everything on 12.3.0 — the version this
package now forces on every installer:

```
Pillow 12.3.0
4375 passed, 9 skipped, 22 subtests passed
```

Built the wheel and confirmed the floors reach the metadata installers read:

```
Requires-Python: >=3.10
Requires-Dist: selenium>=4.0.0
Requires-Dist: requests>=2.33.0
Requires-Dist: python-dotenv>=1.0.0
Requires-Dist: webdriver-manager>=4.0.0
Requires-Dist: defusedxml>=0.7.1
Requires-Dist: Pillow>=12.3.0
```

`twine check` PASSED. Every installed version satisfies its declared floor.

Should publish normally — this changes the package's install contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)